### PR TITLE
feat(controls): add spotlight instructions with spotlight

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -178,3 +178,15 @@ aside a:visited, .link {
   max-height: 300px;
   max-width: 300px;
 }
+
+.spotlightControls {
+  position: absolute;
+  display: none;
+  background-color: rgba(0,60,136,0.5);
+  border-radius: 2px;
+  padding: 2px 5px;
+  top: calc(.5em);
+  left: 3rem;
+  color: white;
+  border: 3px rgba(255,255,255,0.4) solid;
+}

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -1,5 +1,6 @@
 <template>
   <div id="map" ref="map">
+    <div class="spotlightControls" ref="spotlightControls">press ↑ or ↓ to change spotlight size</div>
     <div ref="vimeoPopup" class="ol-popup ol-vimeopopup">
       <div ref="vimeoPopupCloser" class="ol-popup-closer" v-on:click="closePopup"></div>
       <div class="ol-popup-content" ref="vimeoPopupContent"></div>
@@ -48,7 +49,7 @@ import {Vector as VectorLayer} from 'ol/layer'
 import {Vector as VectorSource} from 'ol/source' // OSM
 import {GeoJSON} from 'ol/format'
 import {Style, Stroke, Fill, Icon, Circle} from 'ol/style'
-import {ScaleLine, defaults as defaultControls, ZoomSlider} from 'ol/control'
+import {ScaleLine, defaults as defaultControls, Control} from 'ol/control'
 import {fromLonLat} from 'ol/proj'
 
 import {eventBus} from '../main'
@@ -173,7 +174,10 @@ export default {
             new ScaleLine({
               units: 'us',
               minWidth: 150
-            })
+            }),
+            new Control({
+              element: document.querySelector('.spotlightControls')
+            }),
           ])
         })
         this.toggleScaleLine()
@@ -218,6 +222,15 @@ export default {
           const hit = this.olmap.hasFeatureAtPixel(pixel)
           this.$refs.map.style.cursor = hit ? 'pointer' : ''
         })
+        this.olmap.on('moveend', function(e) {
+          const zoomLevel = this.getView().getZoom();
+          const spotlightControls = document.querySelector('.spotlightControls');
+          if (zoomLevel >= 14) {
+            spotlightControls.style.display = 'block';
+          } else {
+            spotlightControls.style.display = 'none';
+          }
+        });
       }
     },
     closePopup: function () {

--- a/src/components/MapPetropolis.vue
+++ b/src/components/MapPetropolis.vue
@@ -9,7 +9,6 @@ import {fromLonLat} from 'ol/proj'
 import {easeOut} from 'ol/easing.js'
 import {Style, Icon, Text, Fill, Stroke} from 'ol/style'
 import {unByKey} from 'ol/Observable.js'
-
 import {eventBus} from '../main'
 import MediaLightBox from './MediaLightBox.js'
 import AppLightBox from './AppLightBox.vue'


### PR DESCRIPTION
Issue: https://github.com/Brian393/petropolis/issues/13

I spent some time reading through the code and figuring out how it all works!

This branch adds some instructions for when the spotlight is present.

Here's what it looks like, but it only happens when the spotlight is active, otherwise it is hidden.
<img width="366" alt="image" src="https://user-images.githubusercontent.com/1361104/79616535-ed3a6e00-80ca-11ea-8901-a9e34bd8df2f.png">

I thought about making a slider, and I don't think that's necessary. Also, my prior understanding based on our conversation was that the pipelines disappear under the spotlight: they don't. So there's no need for a spotlight toggle, in my opinion.

Also, you may notice that I didn't include the "Shift" key. That's because the "Shift" key is not needed to zoom.

Please test and merge, @Brian393!