### PR TITLE
fix colormap #74

### DIFF
--- a/app/client/public/static/app-conf.json
+++ b/app/client/public/static/app-conf.json
@@ -874,10 +874,7 @@
         "maxResolution": 4891.97,
         "isInteractive": true,
         "style": {
-          "strokeColor": "#09D8F4",
-          "strokeWidth": 1,
-          "hoverTextColor": "white",
-          "hoverBackgroundColor": "#000000"
+         "styleRef": "colorMapStyle"
         }
       },
       {
@@ -896,10 +893,7 @@
         "maxResolution": 640000,
         "isInteractive": true,
         "style": {
-          "strokeColor": "#09D8F4",
-          "strokeWidth": 1,
-          "hoverTextColor": "white",
-          "hoverBackgroundColor": "#000000"
+         "styleRef": "colorMapStyle"
         }
       },
       {

--- a/app/client/src/components/viewer/ol/Map.vue
+++ b/app/client/src/components/viewer/ol/Map.vue
@@ -252,7 +252,7 @@ export default {
       // Create popup overlay for get info
       me.createPopupOverlay();
       // Fetch gas pipes entities for styling
-      me.fetchGasPipesEntities();
+      me.fetchColorMapEntities();
       // Remove layers with no entity property as it will
       // not work with Corporate Networks. (A describe fetaure type )
       // for every layer is needed.
@@ -1062,7 +1062,7 @@ export default {
       }
     },
     ...mapActions('map', {
-      fetchGasPipesEntities: 'fetchGasPipesEntities'
+      fetchColorMapEntities: 'fetchColorMapEntities'
     }),
     ...mapMutations('map', {
       setMap: 'SET_MAP',
@@ -1099,6 +1099,7 @@ export default {
       this.geoserverLayerNames = null;
       this.selectedCoorpNetworkEntity = null;
       this.createLayers();
+      this.fetchColorMapEntities();
     }
   }
 };

--- a/app/client/src/factory/OlLayer.js
+++ b/app/client/src/factory/OlLayer.js
@@ -89,7 +89,7 @@ export const LayerFactory = {
       const props = { ...styleProps, ...stylePropsFn };
       return styleFn(styleField, props);
     } else if (styleRef) {
-      return styleRefs[styleRef]();
+      return styleRefs[styleRef](layerName);
     } else {
       return OlStyleFactory.getInstance(styleProps);
     }

--- a/app/client/src/style/OlStyleDefs.js
+++ b/app/client/src/style/OlStyleDefs.js
@@ -4,7 +4,6 @@ import OlFill from 'ol/style/Fill';
 import OlCircle from 'ol/style/Circle';
 import store from '../store/modules/map';
 
-
 let strokeColor = 'rgba(236, 236, 236, 0.7)';
 let fillColor = 'rgba(255,0,0, 0.2)';
 let imageColor = 'blue';
@@ -75,7 +74,6 @@ export function popupInfoStyle() {
   return styleFunction;
 }
 
-
 export function networkCorpHighlightStyle() {
   const styleFunction = () => {
     const styles = [];
@@ -93,7 +91,7 @@ export function networkCorpHighlightStyle() {
           fill: new OlFill({
             color: imageColor
           })
-        }),
+        })
       })
     );
 
@@ -186,14 +184,15 @@ export function baseStyle(propertyName, config) {
   return styleFunction;
 }
 
-export function gasePipeStyle() {
+export function colorMapStyle(layerName) {
   const styleFunction = feature => {
-    const entity = feature.get('Operator');
-    if (store.state.gasFieldEntitiesColors[entity] && entity) {
+    const entity = feature.get('entity');
+    const colors = store.state.colorMapEntities[layerName];
+    if (colors && colors[entity] && entity) {
       if (!styleCache[entity]) {
         styleCache[entity] = new OlStyle({
           stroke: new OlStroke({
-            color: store.state.gasFieldEntitiesColors[entity],
+            color: colors[entity],
             width: 2.5
           })
         });
@@ -215,7 +214,7 @@ export const styleRefs = {
   defaultStyle: defaultStyle,
   popupInfoStyle: popupInfoStyle,
   baseStyle: baseStyle,
-  gasePipeStyle: gasePipeStyle
+  colorMapStyle: colorMapStyle
 };
 
 export const layersStylePropFn = {


### PR DESCRIPTION
Now the colormap can be used with all vector layers. 
Adding the following configuration will assign the style. 
```
"style": {
         "styleRef": "colorMapStyle"
        }
```
By default it will fetch the distinct values of that layer from geoserver. An additional parameter can be added in the style config object called "tableName" in case the db table name is not the same as geoserver layer name. 